### PR TITLE
Add hashable check to fixture teardown

### DIFF
--- a/pytest_exact_fixtures/__init__.py
+++ b/pytest_exact_fixtures/__init__.py
@@ -8,7 +8,7 @@ from _pytest.fixtures import (
     scopes,
     scopenum_function,
 )
-from collections import defaultdict
+from collections import defaultdict, Hashable
 import operator
 import pytest
 
@@ -165,6 +165,8 @@ class LayerManager(object):
         keylist = []
         nextitem_name2fixturedefs = nextitem._fixtureinfo.name2fixturedefs
         for argname, fixturedef in item._fixtureinfo.name2fixturedefs.items():
+            if not isinstance(fixturedef, Hashable):
+                continue
             if not hasattr(fixturedef[-1], 'cached_result'):
                 continue
             nextitem_fixturedef = nextitem_name2fixturedefs.get(argname, None)


### PR DESCRIPTION
I was troubleshooting some minor errors in our snovault tests.  It seems ones using pytest parameterize would show errors when tearing down the fixtures.  Like for this test,

https://github.com/ENCODE-DCC/snovault/blob/dev/src/snovault/tests/test_key.py#L44

The error,
ERROR src/snovault/tests/test_key.py::test_unique_key[item1] - TypeError: unhashable type: 'list'
would occur here, 
https://github.com/lrowe/pytest_exact_fixtures/blob/master/pytest_exact_fixtures/__init__.py#L173

The problem was 'name2fixturedefs'  here,
https://github.com/lrowe/pytest_exact_fixtures/blob/master/pytest_exact_fixtures/__init__.py#L24
would sometimes return a LIST of fixture definitions.  Which is not hashable.  So I added a check for this in the tear down function.